### PR TITLE
Support for restricting SaaS Administrators to a limited set of users

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ It is recommended to attempt starting Drio-Controller Ubuntu server. There is no
 1. Run ```./setup.sh```
 1. Run ```./start.sh```
 1. The start script executed in the previous step will start all components in the right order. Every service group is started using docker compose and that means any docker image not available locally will be downloaded from docker hub.
-1. Run ```./vault/scripts/get-saas-admin-pass.sh``` to get the SaaS Admin login password. The SaaS Admin username is *saas-admin@drio.ai*.
+1. Support for OAuth has been added to login as SaaS Administrator. There are a subset of user emails that are allowed to login as SaaS Administrator. Add yourself as a SaaS Administrator by setting the environment variable DRIO_SAAS_ADMINS.
+1. DRIO_SAAS_ADMINS can be set to 1 or more emails. Multiple emails must be comma separated like ```export DRIO_SAAS_ADMINS="user1@drio.ai,user2@drio.ai"```
+1. Run ```./vault/scripts/get-saas-admin-pass.sh``` to get the SaaS Administrator login password. The SaaS Administrator username is *saas-admin@drio.ai*.
 
 Drio Controller can be accessed at 127.0.0.1:8080 from the Host it is being run on
 
@@ -61,8 +63,8 @@ Drio Controller can be accessed at 127.0.0.1:8080 from the Host it is being run 
 1. Run ```make start``` to start uiserver
 1. UI Server will take a little while to complete initialization. You can run ```docker logs --follow uiserver``` to follow progress
 1. Initialization is complete when you see the log line 'Accepting connections at http://localhost:3001' and a similar log for :3000
-1. Point your browser to http://localhost:3000 to access SaaS Admin portal
-1. Point your browser to http://localhost:3001 to access Root Admin portal
+1. Point your browser to http://localhost:3000 to access SaaS Administrator portal
+1. Point your browser to http://localhost:3001 to access Root Administrator portal
 
 # UI Stop
 1. ```cd ui``` in the ops repository

--- a/controller/compose/controller.yml
+++ b/controller/compose/controller.yml
@@ -16,6 +16,8 @@ services:
       - POSTGRES_DB=example
       - POSTGRES_PASSWORD_FILE=/run/secrets/configdb-password
       - VAULT_ADDR=http://vault:8200
+      - DRIO_DEFAULT_SAAS_ADMINS=${DRIO_DEFAULT_SAAS_ADMINS}
+      - DRIO_SAAS_ADMINS=${DRIO_SAAS_ADMINS:-""}
     env_file:
       - ../../vault/compose/tokens/drio-controller/drio-controller-role.env
     expose:

--- a/controller/docker/dbinit/0003setadmins.sh
+++ b/controller/docker/dbinit/0003setadmins.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+if [[ ! -z ${DRIO_SAAS_ADMINS} ]]; then
+    DRIO_DEFAULT_SAAS_ADMINS="${DRIO_DEFAULT_SAAS_ADMINS},${DRIO_SAAS_ADMINS}"
+fi
+
+# Split on comma
+IFS=','
+for admin in ${DRIO_DEFAULT_SAAS_ADMINS}; do
+    # Remove leading and trailing spaces if any
+    admin=$(echo ${admin} | xargs)
+    psql --dbname=drio --command "INSERT INTO main.admins(email) VALUES('${admin}');"
+done

--- a/controller/environment/controller.env
+++ b/controller/environment/controller.env
@@ -16,4 +16,4 @@ NGINX_VERSION=latest
 NGINX_LISTEN_PORT=8080
 
 # Drio Controller settings
-DRIO_DEFAULT_SAAS_ADMINS="sraghavan@drio.ai,adeb@drio.ai,aloke.guha@drio.ai,dilip@drio.ai"
+DRIO_DEFAULT_SAAS_ADMINS="sraghavan@drio.ai"

--- a/controller/environment/controller.env
+++ b/controller/environment/controller.env
@@ -1,11 +1,19 @@
+# Configuration database settings
 CONFIGDB_IMAGE=drioinc/postgres
-CONFIGDB_VERSION=1.4
+CONFIGDB_VERSION=1.5
 CONFIGDB_PORT=5432
+
+# API Service settings
 APISERVICE_IMAGE=drioinc/apiservice
 APISERVICE_VERSION=1.15.0
 APISERVICE_DEPLOYMENT_TYPE=dev
 APISERVICE_PORT=8080
 APISERVICE_SCALE=2
+
+# Loadbalancer settings
 NGINX_IMAGE=nginx
 NGINX_VERSION=latest
 NGINX_LISTEN_PORT=8080
+
+# Drio Controller settings
+DRIO_DEFAULT_SAAS_ADMINS="sraghavan@drio.ai,adeb@drio.ai,aloke.guha@drio.ai,dilip@drio.ai"


### PR DESCRIPTION
Support for restricting SaaS Administrators to a limited set of users. Added steps to add more users to administrators list to support local controller deployments.